### PR TITLE
use double values

### DIFF
--- a/monspec/queue-master_perfsig.json
+++ b/monspec/queue-master_perfsig.json
@@ -4,15 +4,15 @@
             "timeseriesId" : "com.dynatrace.builtin:service.responsetime",
             "aggregation" : "avg",
             "tags" : "app:queue-master,environment:dev",
-            "upperLimit" : 3000,
-            "lowerLimit" : 2800
+            "upperLimit" : 3000.0,
+            "lowerLimit" : 2800.0
         },
         {
             "timeseriesId" : "com.dynatrace.builtin:service.failurerate",
             "aggregation" : "avg",
             "tags" : "app:queue-master,environment:dev",
-            "upperLimit" : 5,
-            "lowerLimit" : 0
+            "upperLimit" : 5.0,
+            "lowerLimit" : 0.0
         }
     ]
 }


### PR DESCRIPTION
otherwise the performance signature plugin will set the values to 1